### PR TITLE
Fix problem when starting server on linux

### DIFF
--- a/src/linux/server.sh
+++ b/src/linux/server.sh
@@ -19,17 +19,17 @@ fullcommand="$1" ; shift
 fulldir="`dirname \"$fullcommand\"`"
 lastdir="`basename \"$fulldir\"`"
 command="`basename \"$fullcommand\"`"
-usecommand="$lastdir/$command"
 
 cd "$fulldir/.."
 
 case "$action" in 
     start)
-	sh "$usecommand" "$@" &
+	cd "./server"
+	sh "$command" "$@" &
 	;;
     autorestart)
 	while : ; do
-            sh "$usecommand" "$@" &
+            sh "$command" "$@" &
 	    echo Server was stopped or crashed, restarting...
 	done
 	;;

--- a/src/linux/server.sh
+++ b/src/linux/server.sh
@@ -17,7 +17,6 @@ action="$1" ; shift
 #handle spaces in install directory.
 fullcommand="$1" ; shift
 fulldir="`dirname \"$fullcommand\"`"
-lastdir="`basename \"$fulldir\"`"
 command="`basename \"$fullcommand\"`"
 
 cd "$fulldir/.."


### PR DESCRIPTION
For some reason the server.sh does not execute properly the command and returns a error, this fix the issue by goind directly to the server folder, the only problem left is that the STOP command doesn't kill the srcds_run process so it keeps restarting. Fixes #168 