### PR TITLE
- fixed Server was not detected on Linux

### DIFF
--- a/src/server_support.tcl
+++ b/src/server_support.tcl
@@ -435,7 +435,7 @@ proc UpdateServer {} {
 
 proc DetectServerInstalled {sd} {
     global srcdsName
-    if { [file exists "$sd"] && [file isdirectory "$sd"] && [file executable "$sd/$srcdsName"] && [file isdirectory "$sd/csgo"]} {
+    if { [file exists "$sd"] && [file isdirectory "$sd"] && [file exists "$sd/$srcdsName"] && [file isdirectory "$sd/csgo"]} {
         return true
     }
     return false


### PR DESCRIPTION
srcdsName on linux is "srcds_run" which is  not executable. Therefore this check always returns false. 